### PR TITLE
chore: update dependency react-tabs to v4

### DIFF
--- a/csms-ui/package.json
+++ b/csms-ui/package.json
@@ -50,7 +50,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-scripts": "4.0.3",
-    "react-tabs": "4.0.1",
+    "react-tabs": "4.2.0",
     "typescript": "4.6.3",
     "uuid": "8.3.2",
     "web-vitals": "2.1.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,7 +126,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2
       react-scripts: 4.0.3
-      react-tabs: 4.0.1
+      react-tabs: 4.2.0
       typescript: 4.6.3
       uuid: 8.3.2
       web-vitals: 2.1.4
@@ -146,7 +146,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-scripts: 4.0.3_react@17.0.2+typescript@4.6.3
-      react-tabs: 4.0.1_react@17.0.2
+      react-tabs: 4.2.0_react@17.0.2
       typescript: 4.6.3
       uuid: 8.3.2
       web-vitals: 2.1.4
@@ -11468,10 +11468,10 @@ packages:
       - webpack-plugin-serve
     dev: false
 
-  /react-tabs/4.0.1_react@17.0.2:
-    resolution: {integrity: sha512-Xldj56RHhaRd37iftOwnnjsFEemHY2R07EQ9x5EqOApGauxhdLi7fc/sEKJrtFANHnasNXzSnCWdJ0ulEamMoQ==}
+  /react-tabs/4.2.0_react@17.0.2:
+    resolution: {integrity: sha512-3DifAM5Xbi4EzdzPsmJTxdiW0/QRqvtOZ+ubWQrlruG/e3WVQo+hVcqGB/GdwL8WNz7yGFPk6jiN9Qrxw26WIw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-0
+      react: ^16.8.0 || ^17.0.0-0 || ^18.0.0
     dependencies:
       clsx: 1.1.1
       prop-types: 15.8.1


### PR DESCRIPTION
In GitLab by @bot-4s1 on Mar 1, 2022, 20:14

This MR contains the following updates:

| Package | Type | Update | Change |
|---|---|---|---|
| [react-tabs](https://github.com/reactjs/react-tabs) | dependencies | major | [`3.2.3` -> `4.0.1`](https://renovatebot.com/diffs/npm/react-tabs/3.2.3/4.0.1) |

---

### Release Notes

<details>
<summary>reactjs/react-tabs</summary>

### [`v4.0.1`](https://github.com/reactjs/react-tabs/releases/v4.0.1)

[Compare Source](https://github.com/reactjs/react-tabs/compare/v4.0.0...v4.0.1)

##### Bug Fixes

-   Requires React version 16.8 or newer ([397673d](https://github.com/reactjs/react-tabs/commit/397673d17f49d67bc788a5cab206da1f7002cd46))

### [`v4.0.0`](https://github.com/reactjs/react-tabs/releases/v4.0.0)

[Compare Source](https://github.com/reactjs/react-tabs/compare/v3.2.3...v4.0.0)

##### Features

-   Always set focus on tabs ([4512dad](https://github.com/reactjs/react-tabs/commit/4512dadaeaed3ac0e14fe0f5a2df1baf0ebe5e48)), closes [#&#8203;272](https://github.com/reactjs/react-tabs/issues/272)
-   Updated all the class components to newer functional components ([b2159c9](https://github.com/reactjs/react-tabs/commit/b2159c91b0a8836a25a5cf0c9cd4b57e929ceece))

##### BREAKING CHANGES

-   The tabs are now instantly focused on click and not just by double-click. The default styling has been adapted for that, so that there is no outline shown anymore on focus.
-   Requires react 16.8 or newer

</details>

---

### Configuration

📅 **Schedule**: At any time (no schedule defined).

🚦 **Automerge**: Disabled by config. Please merge this manually once you are satisfied.

♻ **Rebasing**: Whenever MR becomes conflicted, or you tick the rebase/retry checkbox.

🔕 **Ignore**: Close this MR and you won't be reminded about this update again.

---

 - [ ] <!-- rebase-check -->If you want to rebase/retry this MR, click this checkbox.

---

This MR has been generated by [Renovate Bot](https://github.com/renovatebot/renovate).