### PR TITLE
chore: update dependency @testing-library/user-event to v14

### DIFF
--- a/csms-ui/package.json
+++ b/csms-ui/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/react-fontawesome": "0.1.18",
     "@testing-library/dom": "8.12.0",
     "@testing-library/react": "11.2.7",
-    "@testing-library/user-event": "13.5.0",
+    "@testing-library/user-event": "14.0.4",
     "@types/react": "17.0.43",
     "@types/react-dom": "17.0.14",
     "bootstrap": "4.6.1",

--- a/css-ui/package.json
+++ b/css-ui/package.json
@@ -40,7 +40,7 @@
     "@4s1/ocpp-lib": "workspace:*",
     "@testing-library/dom": "8.12.0",
     "@testing-library/react": "11.2.7",
-    "@testing-library/user-event": "13.5.0",
+    "@testing-library/user-event": "14.0.4",
     "@types/react": "17.0.43",
     "@types/react-dom": "17.0.14",
     "bootstrap": "4.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
       '@fortawesome/react-fontawesome': 0.1.18
       '@testing-library/dom': 8.12.0
       '@testing-library/react': 11.2.7
-      '@testing-library/user-event': 13.5.0
+      '@testing-library/user-event': 14.0.4
       '@types/node': 14.18.12
       '@types/react': 17.0.43
       '@types/react-dom': 17.0.14
@@ -138,7 +138,7 @@ importers:
       '@fortawesome/react-fontawesome': 0.1.18_6909f5698ccb6b468185370814560628
       '@testing-library/dom': 8.12.0
       '@testing-library/react': 11.2.7_react-dom@17.0.2+react@17.0.2
-      '@testing-library/user-event': 13.5.0_@testing-library+dom@8.12.0
+      '@testing-library/user-event': 14.0.4_@testing-library+dom@8.12.0
       '@types/react': 17.0.43
       '@types/react-dom': 17.0.14
       bootstrap: 4.6.1
@@ -236,7 +236,7 @@ importers:
       '@4s1/ocpp-lib': workspace:*
       '@testing-library/dom': 8.12.0
       '@testing-library/react': 11.2.7
-      '@testing-library/user-event': 13.5.0
+      '@testing-library/user-event': 14.0.4
       '@types/node': 14.18.12
       '@types/react': 17.0.43
       '@types/react-dom': 17.0.14
@@ -254,7 +254,7 @@ importers:
       '@4s1/ocpp-lib': link:../ocpp-lib
       '@testing-library/dom': 8.12.0
       '@testing-library/react': 11.2.7_react-dom@17.0.2+react@17.0.2
-      '@testing-library/user-event': 13.5.0_@testing-library+dom@8.12.0
+      '@testing-library/user-event': 14.0.4_@testing-library+dom@8.12.0
       '@types/react': 17.0.43
       '@types/react-dom': 17.0.14
       bootstrap: 4.6.1
@@ -2787,13 +2787,12 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@testing-library/user-event/13.5.0_@testing-library+dom@8.12.0:
-    resolution: {integrity: sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==}
-    engines: {node: '>=10', npm: '>=6'}
+  /@testing-library/user-event/14.0.4_@testing-library+dom@8.12.0:
+    resolution: {integrity: sha512-VBZe5lcUsmrQyOwIFvqOxLBoaTw1/Qy4Ek+VgmFYs719bs2SxUp42vbsb7ATlQDkHdj4OIQlucfpwxe5WoG1jA==}
+    engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
     dependencies:
-      '@babel/runtime': 7.15.4
       '@testing-library/dom': 8.12.0
     dev: false
 


### PR DESCRIPTION
In GitLab by @bot-4s1 on Mar 29, 2022, 15:07

This MR contains the following updates:

| Package | Type | Update | Change |
|---|---|---|---|
| [@testing-library/user-event](https://github.com/testing-library/user-event) | dependencies | major | [`13.5.0` -> `14.0.4`](https://renovatebot.com/diffs/npm/@testing-library%2fuser-event/13.5.0/14.0.4) |

---

### Release Notes

<details>
<summary>testing-library/user-event</summary>

### [`v14.0.4`](https://github.com/testing-library/user-event/releases/v14.0.4)

[Compare Source](https://github.com/testing-library/user-event/compare/v14.0.3...v14.0.4)

##### [14.0.4](https://github.com/testing-library/user-event/compare/v14.0.3...v14.0.4) (2022-04-01)

##### Bug Fixes

-   track calls to `HTMLInputElement.select()` ([#&#8203;898](https://github.com/testing-library/user-event/issues/898)) ([6d36828](https://github.com/testing-library/user-event/commit/6d36828e22d0ab65d94178daadb131ec92bae676))

### [`v14.0.3`](https://github.com/testing-library/user-event/releases/v14.0.3)

[Compare Source](https://github.com/testing-library/user-event/compare/v14.0.2...v14.0.3)

##### [14.0.3](https://github.com/testing-library/user-event/compare/v14.0.2...v14.0.3) (2022-03-31)

##### Bug Fixes

-   **pointer:** change selection before dispatching `focus` ([#&#8203;895](https://github.com/testing-library/user-event/issues/895)) ([06f12a6](https://github.com/testing-library/user-event/commit/06f12a6475e6332a048c8c0770a36661af3fea20))

### [`v14.0.2`](https://github.com/testing-library/user-event/releases/v14.0.2)

[Compare Source](https://github.com/testing-library/user-event/compare/v14.0.1...v14.0.2)

##### [14.0.2](https://github.com/testing-library/user-event/compare/v14.0.1...v14.0.2) (2022-03-31)

##### Bug Fixes

-   work around shadowed globals ([#&#8203;892](https://github.com/testing-library/user-event/issues/892)) ([126d2e7](https://github.com/testing-library/user-event/commit/126d2e7b7853e0cf16640e01316e3c602ef2b640))

### [`v14.0.1`](https://github.com/testing-library/user-event/releases/v14.0.1)

[Compare Source](https://github.com/testing-library/user-event/compare/v14.0.0...v14.0.1)

##### [14.0.1](https://github.com/testing-library/user-event/compare/v14.0.0...v14.0.1) (2022-03-31)

##### Bug Fixes

-   maintain UI value on controlled number input ([#&#8203;889](https://github.com/testing-library/user-event/issues/889)) ([a7f9906](https://github.com/testing-library/user-event/commit/a7f99066a5623e0bd05ce3092def09907a1d4dc6))
-   **pointer:** support nested select ([#&#8203;888](https://github.com/testing-library/user-event/issues/888)) ([e23e559](https://github.com/testing-library/user-event/commit/e23e559297c33d86c96d217c414d4d230e14c7a2))

### [`v14.0.0`](https://github.com/testing-library/user-event/releases/v14.0.0)

[Compare Source](https://github.com/testing-library/user-event/compare/v13.5.0...v14.0.0)

##### ⚠ BREAKING CHANGES

-   **APIs always return a Promise.**
-   **pointer:** `skipPointerEvents` has been removed.
    Use `pointerEventsCheck: PointerEventsCheckLevel.Never` instead.
-   **upload:** `init` parameter has been removed from `userEvent.upload`.
-   The `userEvent.paste` API has new parameters.
-   `{ctrl}`, `{del}`, `{esc}` no longer describe a key. Use `{Control}`, `{Delete}`, `{Escape}` instead.
-   `{alt}`, `{ctrl}`, `{meta}`, `{shift}` no longer imply not releasing the key. Use `{Alt>}`, `{Control>}`, `{Meta>}`, `{Shift>}` instead.
-   `init` parameter has been removed from these APIs:
    -   `userEvent.click`
    -   `userEvent.dblClick`
    -   `userEvent.tripleClick`
    -   `userEvent.hover`
    -   `userEvent.unhover`
    -   `userEvent.selectOptions`
    -   `userEvent.deselectOptions`
-   `userEvent.upload` no longer supports `clickInit`
    as part of its `init` parameter.
-   Behavior for special key descriptor `{selectall}` has been removed.
-   Support for `keyCode` property on keyboard events has been removed.
-   An error is thrown when calling `userEvent.clear` on an element which is not editable.
-   An error is thrown when event handlers prevent `userEvent.clear` from focussing/selecting content.
-   **tab:** The `focusTrap` option has been removed from `userEvent.tab()`.
-   **type:** `userEvent.type` does no longer move the cursor
    if used with `skipClick=false` and without `initialSelectionStart`.
-   The implementation of pointer related APIs was replaced.
    This might break tests relying on unintended side-effects of the previous implementation.
-   Support for node 10 was removed as it reached its end-of-life.

##### Features

-   async APIs ([#&#8203;790](https://github.com/testing-library/user-event/issues/790)) ([86860cc](https://github.com/testing-library/user-event/commit/86860cc5fd1b59a6b34ffd00c96d22520f4aa56e))
-   keep track of document state in UI ([#&#8203;747](https://github.com/testing-library/user-event/issues/747)) ([73e62d0](https://github.com/testing-library/user-event/commit/73e62d03877c736e18bc9e394e4ed07333b99933))
-   rewrite selection handling ([#&#8203;776](https://github.com/testing-library/user-event/issues/776)) ([968c2c4](https://github.com/testing-library/user-event/commit/968c2c429e8d67974b9a313d1efab7d78c35c207))
-   **event:** support `beforeinput` ([#&#8203;851](https://github.com/testing-library/user-event/issues/851)) ([8890bd6](https://github.com/testing-library/user-event/commit/8890bd6d17376205f553620148852d63f84d5565))
-   add `pointer` API ([#&#8203;750](https://github.com/testing-library/user-event/issues/750)) ([c12ee44](https://github.com/testing-library/user-event/commit/c12ee44dc2caa19c5df98442759fcc9ae4ba167f))
-   add `setup` API ([#&#8203;746](https://github.com/testing-library/user-event/issues/746)) ([719ba03](https://github.com/testing-library/user-event/commit/719ba03af5647e09cd734f419ce5f234af60328a))
-   add `userEvent.copy` and `userEvent.cut` ([#&#8203;787](https://github.com/testing-library/user-event/issues/787)) ([8727a2d](https://github.com/testing-library/user-event/commit/8727a2d7b1723287923bf5e6ea1c33844d9cccf5))
-   add `userEvent.tripleClick` API ([#&#8203;773](https://github.com/testing-library/user-event/issues/773)) ([0badabd](https://github.com/testing-library/user-event/commit/0badabdd504b0c42ad9adca94edd96ddb53ae303))
-   apply modifier keys in pointer events ([#&#8203;751](https://github.com/testing-library/user-event/issues/751)) ([e33eb86](https://github.com/testing-library/user-event/commit/e33eb86194e08a0bc46285ca1acb57d6d533fbb7))
-   **keyboard:** add `[Tab]` support ([#&#8203;767](https://github.com/testing-library/user-event/issues/767)) ([87470ff](https://github.com/testing-library/user-event/commit/87470ffe49c93c0b7a858d5c07d660fede90f881))
-   **keyboard:** apply modifier state ([#&#8203;815](https://github.com/testing-library/user-event/issues/815)) ([e9635f6](https://github.com/testing-library/user-event/commit/e9635f656298ef1f96bd255b0d89031e04441537))
-   **keyboard:** move cursor and delete content in contenteditable ([#&#8203;822](https://github.com/testing-library/user-event/issues/822)) ([b83b259](https://github.com/testing-library/user-event/commit/b83b25927a38de2477099ec2ad2ad074a5296ce6))
-   **keyboard:** select all per `{Control}+[KeyA]` ([#&#8203;774](https://github.com/testing-library/user-event/issues/774)) ([ea9b18a](https://github.com/testing-library/user-event/commit/ea9b18a0e96142f7d4cd80009a53be06a1431c07))
-   **pointer:** change selection per pointer ([#&#8203;763](https://github.com/testing-library/user-event/issues/763)) ([17fb8b1](https://github.com/testing-library/user-event/commit/17fb8b14056bb68d1c2fd9e8796c09e00aacd844))
-   **pointer:** introduce `pointerEventsCheck` option ([#&#8203;823](https://github.com/testing-library/user-event/issues/823)) ([e2a5f43](https://github.com/testing-library/user-event/commit/e2a5f434b6e8b0ec0badddec52b54957b6f3320a))
-   remove support for user provided `MouseEventInit` ([#&#8203;784](https://github.com/testing-library/user-event/issues/784)) ([56ebf7d](https://github.com/testing-library/user-event/commit/56ebf7d00620d7696d73e30f7f5d90a7ea02d0f3))
-   **paste:** replace `userEvent.paste` ([#&#8203;785](https://github.com/testing-library/user-event/issues/785)) ([f8fe217](https://github.com/testing-library/user-event/commit/f8fe217fd445a27a62705894eb2c9f5a38a91f42))
-   **clear:** rewrite `userEvent.clear` API ([#&#8203;779](https://github.com/testing-library/user-event/issues/779)) ([1cda1b1](https://github.com/testing-library/user-event/commit/1cda1b1b9726c2e7db213ec543f96b3fde2d10b8))
-   **upload:** replace element properties ([#&#8203;794](https://github.com/testing-library/user-event/issues/794)) ([543eadb](https://github.com/testing-library/user-event/commit/543eadb14d8d0f08d5023edbd3353eb5df591329))

##### Bug Fixes

-   check for inherited `:disabled` ([#&#8203;872](https://github.com/testing-library/user-event/issues/872)) ([1a00fdf](https://github.com/testing-library/user-event/commit/1a00fdfc3085addc4792897aecda202e07c3f5d2))
-   **clipboard:** prevent default behavior on `copy`/`cut` ([#&#8203;866](https://github.com/testing-library/user-event/issues/866)) ([5423094](https://github.com/testing-library/user-event/commit/5423094180cd0946b7440f699933b6569b8639f5))
-   **clipboard:** prevent default behavior on `paste` ([#&#8203;862](https://github.com/testing-library/user-event/issues/862)) ([d3d71ac](https://github.com/testing-library/user-event/commit/d3d71ac65d21f96b36cd1e087b79890bb8e61f03))
-   create MouseEvents per `createEvent` ([#&#8203;781](https://github.com/testing-library/user-event/issues/781)) ([da5b5b7](https://github.com/testing-library/user-event/commit/da5b5b721894b39a4ab9bc2f15afa4123bfda88e))
-   export bundled ESM ([#&#8203;816](https://github.com/testing-library/user-event/issues/816)) ([1a5e2a7](https://github.com/testing-library/user-event/commit/1a5e2a718b03e8523d7c14ba43020d2d9d653b33))
-   export types and commonjs bundle ([#&#8203;821](https://github.com/testing-library/user-event/issues/821)) ([4f56856](https://github.com/testing-library/user-event/commit/4f56856bfc64aa1fcc6ee8ab91050b61ee7c2e7e))
-   **keyboard:** parse escaped bracket followed by descriptor ([#&#8203;814](https://github.com/testing-library/user-event/issues/814)) ([684451f](https://github.com/testing-library/user-event/commit/684451f11b946374dca8a9650fce9fa316d0f032))
-   **keyboard:** parse keyboard input without nesting ([#&#8203;793](https://github.com/testing-library/user-event/issues/793)) ([fafa677](https://github.com/testing-library/user-event/commit/fafa677a0901cab79174eb387b08d051db7129cc))
-   **keyboard:** set `KeyboardEvent.charCode` on `keypress` ([#&#8203;771](https://github.com/testing-library/user-event/issues/771)) ([55e194a](https://github.com/testing-library/user-event/commit/55e194aa96c31844950fa5c74c5ff14a513f0f24))
-   **keyboard:** submit form with `<button/>` on `[Enter]` ([#&#8203;808](https://github.com/testing-library/user-event/issues/808)) ([eca157a](https://github.com/testing-library/user-event/commit/eca157ad8efecfdef8bd955a835d7371c9a45908))
-   log correct docs link for invalid key descriptors ([#&#8203;881](https://github.com/testing-library/user-event/issues/881)) ([28d6604](https://github.com/testing-library/user-event/commit/28d66044e4bbd25b1422c1107db7a5b9a538a150))
-   maintain cursor position on controlled component ([#&#8203;765](https://github.com/testing-library/user-event/issues/765)) ([8f203cc](https://github.com/testing-library/user-event/commit/8f203cc4ad2c3e3bf9de5fcf90925970c7cb8868))
-   **pointer:** blur `activeElement` on click outside of focusable ([#&#8203;834](https://github.com/testing-library/user-event/issues/834)) ([d64167c](https://github.com/testing-library/user-event/commit/d64167ca40506e381aff53c985b19e6d2a8a156d))
-   **pointer:** consider click context ([#&#8203;850](https://github.com/testing-library/user-event/issues/850)) ([ca4482a](https://github.com/testing-library/user-event/commit/ca4482a16bd0da3f7d7e5684fe6bb4650f26a1ee))
-   **pointer:** fire pointer events on disabled elements ([#&#8203;818](https://github.com/testing-library/user-event/issues/818)) ([ef2f4e5](https://github.com/testing-library/user-event/commit/ef2f4e50ee8a53f3cc52deb5982a104be6e9d0ce))
-   **pointer:** honor click handler on `<label/>` ([#&#8203;810](https://github.com/testing-library/user-event/issues/810)) ([2c5d9f1](https://github.com/testing-library/user-event/commit/2c5d9f1369301539826879f95c9f6093f676e2bb))
-   **pointer:** trigger `contextmenu` on `mousedown` ([#&#8203;811](https://github.com/testing-library/user-event/issues/811)) ([e1c4cad](https://github.com/testing-library/user-event/commit/e1c4caded733c7bd41c2f161e1ce6dc1d392d7e5))
-   prepare document in setup ([#&#8203;753](https://github.com/testing-library/user-event/issues/753)) ([65be675](https://github.com/testing-library/user-event/commit/65be6751e3558e85da42f105606b9feb7afc878c))
-   remove deprecated keyboard features ([#&#8203;780](https://github.com/testing-library/user-event/issues/780)) ([45dc39a](https://github.com/testing-library/user-event/commit/45dc39a3f9f08522eb289f0e8ced0b9ede9a1535))
-   remove legacy modifier implementations ([#&#8203;783](https://github.com/testing-library/user-event/issues/783)) ([caea162](https://github.com/testing-library/user-event/commit/caea16238a2d7041d2f15cd8b850ca396eba0de9))
-   replace pointer implementations ([#&#8203;754](https://github.com/testing-library/user-event/issues/754)) ([c04f79b](https://github.com/testing-library/user-event/commit/c04f79b628f123f62fb4a1df5a760be6da6f3582))
-   reset UI selection on setter ([#&#8203;770](https://github.com/testing-library/user-event/issues/770)) ([2733d10](https://github.com/testing-library/user-event/commit/2733d107c8d1ecb111e14099f31672a76ba293e2))
-   **tab:** order `tabIndex>0` before `tabIndex=0` ([#&#8203;809](https://github.com/testing-library/user-event/issues/809)) ([1bc5945](https://github.com/testing-library/user-event/commit/1bc59459e4c7fc6e3c4de7853234f6720b4129f6))
-   **tab:** remove `focusTrap` option ([#&#8203;772](https://github.com/testing-library/user-event/issues/772)) ([a0412c0](https://github.com/testing-library/user-event/commit/a0412c00cdb40ae670e4abbde5c0d30eae68e58b))
-   **tab:** skip elements with `visibility:hidden` ([#&#8203;799](https://github.com/testing-library/user-event/issues/799)) ([a747b0a](https://github.com/testing-library/user-event/commit/a747b0ab07681651bf6b6428471de2dd76bc22df))
-   **upload:** fix order of events ([#&#8203;847](https://github.com/testing-library/user-event/issues/847)) ([214fd03](https://github.com/testing-library/user-event/commit/214fd03e71b23e0bb1ea90f6299008701600e533))

##### Miscellaneous Chores

-   drop support for node 10 ([#&#8203;698](https://github.com/testing-library/user-event/issues/698)) ([ce01cde](https://github.com/testing-library/user-event/commit/ce01cde601e7b7191055d0def319753bbab96493))

</details>

---

### Configuration

📅 **Schedule**: At any time (no schedule defined).

🚦 **Automerge**: Disabled by config. Please merge this manually once you are satisfied.

♻ **Rebasing**: Whenever MR becomes conflicted, or you tick the rebase/retry checkbox.

🔕 **Ignore**: Close this MR and you won't be reminded about this update again.

---

 - [ ] <!-- rebase-check -->If you want to rebase/retry this MR, click this checkbox.

---

This MR has been generated by [Renovate Bot](https://github.com/renovatebot/renovate).